### PR TITLE
feat(Docker): Introduce Docker image construction

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Makefile
+Dockerfile
+.git
+.vscode
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# = Do.Doc  Docker =
+# == Base for build ==
+FROM node:8.9.3-alpine AS build-base
+RUN apk --update --no-cache add python2 build-base git ca-certificates wget file fftw-dev sudo && \
+    update-ca-certificates
+
+# Install global dependencies
+RUN npm i extract-zip
+RUN sudo npm install -g electron node-gyp --unsafe-perm=true --allow-root --save-dev --save-exact
+RUN npm i ajv
+
+# Ready to start do.doc specific dependencies
+
+# == Client ==
+FROM build-base AS build-client
+# Install client dependencies
+WORKDIR /src/l-atelier-des-chercheurs/dodoc/public/
+COPY public/package*.json ./
+RUN npm install --unsafe-perm=true 
+COPY public /src/l-atelier-des-chercheurs/dodoc/public
+#RUN npm run dev --unsafe-perm=true && npm run build --unsafe-perm=true 
+RUN npm run build --unsafe-perm=true
+
+
+# == server ==
+FROM build-base AS build-server
+# Install server dependencies
+WORKDIR /src/l-atelier-des-chercheurs/dodoc
+COPY package*.json ./
+RUN npm install --unsafe-perm=true 
+COPY . /src/l-atelier-des-chercheurs/dodoc/
+RUN npm build --unsafe-perm=true 
+
+# == Serving ==
+FROM node:8.9.3-alpine
+
+RUN apk add --update --no-cache curl
+
+RUN apk update && apk upgrade && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    apk add --no-cache \
+      chromium@edge \
+      nss@edge \
+      harfbuzz@edge \
+      freetype@edge \
+      ttf-freefont@edge
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+RUN yarn add puppeteer@1.17
+
+# Add user so we don't need --no-sandbox.
+# RUN addgroup -S node && adduser -S -g node node \
+RUN mkdir -p /home/node/Downloads \
+    && chown -R node:node /home/node
+#    && chown -R node:node /application
+
+EXPOSE 8080
+
+WORKDIR /src/l-atelier-des-chercheurs/dodoc
+
+COPY . .
+COPY --from=build-server /src/l-atelier-des-chercheurs/dodoc/node_modules node_modules
+COPY --from=build-client /src/l-atelier-des-chercheurs/dodoc/public/dist/ /src/l-atelier-des-chercheurs/dodoc/public/dist/
+COPY --from=build-base /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+HEALTHCHECK --interval=5s \
+            --timeout=5s \
+            --retries=6 \
+            CMD curl -fs http://localhost:8080/ || exit 1
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+USER node
+CMD npm run debug

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	docker build -t  loic_fejoz/dodoc2-dev:latest .
+
+run:
+	docker run -p 8080:8080 -v ~/dodoc-documents:/home/node/Documents -d loic_fejoz/dodoc2-dev
+	docker ps
+
+.PHONY: build run

--- a/core/exporter.js
+++ b/core/exporter.js
@@ -252,7 +252,8 @@ module.exports = (function() {
                 .launch({
                   headless: true,
                   ignoreHTTPSErrors: true,
-                  args: ['--no-sandbox']
+                  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+                  executablePath: '/usr/bin/chromium-browser'
                 })
                 .then(browser => {
                   return browser.newPage();

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "platform-folders": "^0.4.0",
     "portscanner": "^2.2.0",
     "pug": "^2.0.3",
-    "puppeteer": "^1.13.0",
+    "puppeteer": "1.17",
     "quill-render": "^1.0.5",
     "rich-text": "^3.1.0",
     "sharedb": "^1.0.0-beta.22",


### PR DESCRIPTION
Fixed puppeteer version to the one matching Chromium@edge on Alpine.
Explicit executablePath inside exporter.js so that chromium is found.
Add Dockerfile quite compliant with Docker cache strategy.
Also tell puppeteer not to download chromium itself so that we can fix the version.
Related to #377 